### PR TITLE
Add a `--exec` option to `toolup linux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ toolup install aarch64-unknown-none-gnu
 
 ```bash
 # quickly build a kernel image and a minimal rootfs and start qemu-system-<arch> in the terminal
-toolup linux 6.16 -t riscv64-unknown-linux-gnu
+toolup linux 6.16 -a riscv64
 
 # -m will open the kernel menuconfig, since this is `ppc64-`, we can configure a big endian kernel
-toolup linux 6.17 -t ppc64-unknown-linux-gnu -j20 -m
+toolup linux 6.17 -a ppc64 -j20 -m
 ```
 
 qemu userspace emulation


### PR DESCRIPTION
Add a new option that will copy a program from host and run it inside a VM.

Closes #7 

---
```
  -e, --exec <PROGRAM_PATH>
          Copy a program from host and run it in a virtual machine using the built kernel.

          The program's output will be streamed live to the host, and the command will exit with the same exit code as the program running inside the virtual machine.

          Useful for testing a program across different kernel versions and configurations.
```